### PR TITLE
Enable horizontal scrolling for code blocks

### DIFF
--- a/newest-unreleased-changes.md
+++ b/newest-unreleased-changes.md
@@ -6,3 +6,4 @@
 - Added `link_title` frontmadder to separate between the title and the friendly title for the display in listings. Falls back to title if not set.
 - Added `linktitle` content variable.
 - Details shortcode has received significant changes. Added name, title, and class attributes.
+- Added `overflow: auto;` to `pre` element to allow horizontal scrolling when content overflows.

--- a/static/css/theme.css
+++ b/static/css/theme.css
@@ -50,5 +50,5 @@ Note: Style is not verified by sighted people, this is best bet for text display
 
 /* Enable horizontal scrolling on pre elements if content overflows */
 pre {
-    overflow: auto;       
+	overflow: auto;       
 }

--- a/static/css/theme.css
+++ b/static/css/theme.css
@@ -3,7 +3,8 @@ This style file is included in Zluinav theme which is distributed under the term
 
 Note: Style is not verified by sighted people, this is best bet for text display.
 */
-//Skip link to be invisible for sighted visitors
+
+/* Skip link to be invisible for sighted visitors */
 .skip-link {
 	position: absolute;
 	left: -9999px;
@@ -13,7 +14,8 @@ Note: Style is not verified by sighted people, this is best bet for text display
 	overflow: hidden;
 	z-index: -1;
 }
-//When skip link is focused, make visible again.
+
+/* When skip link is focused, make visible again. */
 .skip-link:focus {
 	position: static;
 	width: auto;
@@ -21,6 +23,7 @@ Note: Style is not verified by sighted people, this is best bet for text display
 	overflow: visible;
 	z-index: 1;
 }
+
 .tab {
 	padding: 10px 20px;
 	background-color: #f0f0f0;
@@ -29,15 +32,23 @@ Note: Style is not verified by sighted people, this is best bet for text display
 	cursor: pointer;
 	transition: background-color 0.3s;
 }
+
 .tab:hover {
 	background-color: #ddd;
 }
+
 .tab.active {
 	background-color: #ccc;
 }
+
 .tab-content {
 	padding: 20px;
 	border: 1px solid #ccc;
 	border-top: none;
 	display: none;
+}
+
+/* Enable horizontal scrolling on pre elements if content overflows */
+pre {
+    overflow: auto;       
 }


### PR DESCRIPTION
Based on this [issue](https://github.com/harrymkt/zluinav/issues/8):

- Added `overflow: auto;` to `pre` element to allow horizontal scrolling when content overflows.